### PR TITLE
Pin coin3d to v4.0.0 until pivy is compatible with v4.0.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
         - vtk
         - eigen
         - pybind11
-        - coin3d
+        - coin3d==4.0.0
         - pyside2
         - smesh
         - doxygen  # [build_platform == target_platform]
@@ -73,7 +73,7 @@ requirements:
         - zlib
         - hdf5
         - python
-        - coin3d
+        - coin3d==4.0.0
         - pivy
         - {{ pin_compatible('smesh', max_pin='x.x.x') }}
         - freetype


### PR DESCRIPTION
[`coin3d`](https://github.com/coin3d/coin) recently pushed out a new release, [v4.0.1](https://github.com/coin3d/coin/releases/tag/v4.0.1), which does not have some of the symbols that [`pivy`](https://github.com/coin3d/pivy) uses.  Consequently, this breaks functionality that depends upon `pivy.

Pinning to version 4.0.0 will permit the builds to be successful until `pivy` is updated for the new `coin3d` release.