### PR TITLE
Synchronize qt-main on all platforms.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,7 +9,7 @@ occt:
   - 7.8.1  # [not linux]
   - 7.7.2  # [linux]
 qt_main:  # [linux]
-  - '5.15.13'  # [linux]
+  - '5.15.13'
 vtk:  # [linux]
   - 9.2.6  # [linux]
 vtk:  # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     # sha256:
     patches:
         - patches/osx_arm64_cross_compiling.patch    # [build_platform != target_platform and osx]
+        - patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
 
 build:
     number: {{ build_number }}

--- a/recipe/patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
+++ b/recipe/patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
@@ -1,0 +1,26 @@
+From 691202d1ac48f0ec98c17459e03ac954b8a7fad1 Mon Sep 17 00:00:00 2001
+From: Jacob Oursland <jacob.oursland@gmail.com>
+Date: Tue, 25 Feb 2025 08:54:08 -0800
+Subject: [PATCH] Revert "Mesh: Remove explicit C++17 requirement"
+
+This reverts commit 99b088e94e3a4116e88eb3e27c76c1c3b23c2169.
+---
+ src/Mod/Mesh/App/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/Mod/Mesh/App/CMakeLists.txt b/src/Mod/Mesh/App/CMakeLists.txt
+index e50866df11..59d1ee3a96 100644
+--- a/src/Mod/Mesh/App/CMakeLists.txt
++++ b/src/Mod/Mesh/App/CMakeLists.txt
+@@ -419,6 +419,8 @@ endif ()
+ 
+ add_library(Mesh SHARED ${Core_SRCS} ${WildMagic4_SRCS} ${Mesh_SRCS})
+ target_link_libraries(Mesh ${Mesh_LIBS})
++set_target_properties(Mesh PROPERTIES CXX_STANDARD_REQUIRED ON)
++set_target_properties(Mesh PROPERTIES CXX_STANDARD 17)
+ if (FREECAD_WARN_ERROR)
+     target_compile_warn_error(Mesh)
+ endif()
+-- 
+2.48.1
+


### PR DESCRIPTION
Builds on macOS and Windows are failing.  From what I can tell, the key difference is the version of `qt-main`.  This PR synchronizes the same `qt-main` for all three platforms.