### PR TITLE
Use C++17 on the weekly builds.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
     # sha256:
     patches:
         - patches/osx_arm64_cross_compiling.patch    # [build_platform != target_platform and osx]
+        - patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
+        - patches/0001-Revert-CMake-Update-compiler-and-standard-mins.patch
 
 build:
     number: {{ build_number }}

--- a/recipe/patches/0001-Revert-CMake-Update-compiler-and-standard-mins.patch
+++ b/recipe/patches/0001-Revert-CMake-Update-compiler-and-standard-mins.patch
@@ -1,0 +1,57 @@
+From 667e071e33297f1096333a51fc8b9ba78f310b9a Mon Sep 17 00:00:00 2001
+From: Jacob Oursland <jacob.oursland@gmail.com>
+Date: Tue, 25 Feb 2025 08:59:35 -0800
+Subject: [PATCH] Revert "CMake: Update compiler and standard mins"
+
+This reverts commit 87ce62f8ace455495f1894911f8fabe962d35317.
+---
+ .../CompilerChecksAndSetups.cmake             | 28 ++++++++++---------
+ 1 file changed, 15 insertions(+), 13 deletions(-)
+
+diff --git a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+index 1d3c233df1..efd20ef2a0 100644
+--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
++++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+@@ -20,24 +20,26 @@ macro(CompilerChecksAndSetups)
+                         OUTPUT_VARIABLE CMAKE_CXX_COMPILER_VERSION)
+     endif(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION)
+ 
+-    # Enabled C++20 for Freecad 1.1 and later
+-    set(BUILD_ENABLE_CXX_STD "C++20"  CACHE STRING  "Enable C++ standard")
+-    set_property(CACHE BUILD_ENABLE_CXX_STD PROPERTY STRINGS
+-                 "C++20"
+-                 "C++23"
+-    )
+-
+-    if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.2)
+-        message(FATAL_ERROR "FreeCAD 1.1 and later requires C++20.  G++ must be 11.2 or later, the used version is ${CMAKE_CXX_COMPILER_VERSION}")
+-    elseif(CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+-        message(FATAL_ERROR "FreeCAD 1.1 and later requires C++20.  Clang must be 14.0 or later, the used version is ${CMAKE_CXX_COMPILER_VERSION}")
+-    endif()
++    # Enabled C++17 for Freecad 0.20 and later
++        set(BUILD_ENABLE_CXX_STD "C++17"  CACHE STRING  "Enable C++ standard")
++        set_property(CACHE BUILD_ENABLE_CXX_STD PROPERTY STRINGS
++                     "C++17"
++                     "C++20"
++        )
++
++        if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
++            message(FATAL_ERROR "FreeCAD 0.20 and later requires C++17.  G++ must be 7.3 or later, the used version is ${CMAKE_CXX_COMPILER_VERSION}")
++        elseif(CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
++            message(FATAL_ERROR "FreeCAD 0.20 and later requires C++17.  Clang must be 6.0 or later, the used version is ${CMAKE_CXX_COMPILER_VERSION}")
++        endif()
+ 
+     # Escape the two plus chars as otherwise cmake complains about invalid regex
+     if(${BUILD_ENABLE_CXX_STD} MATCHES "C\\+\\+23")
+         set(CMAKE_CXX_STANDARD 23)
+-    else()
++    elseif(${BUILD_ENABLE_CXX_STD} MATCHES "C\\+\\+20")
+         set(CMAKE_CXX_STANDARD 20)
++    else()#Enabled C++17
++        set(CMAKE_CXX_STANDARD 17)
+     endif()
+ 
+     # Log the compiler and version
+-- 
+2.48.1
+

--- a/recipe/patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
+++ b/recipe/patches/0001-Revert-Mesh-Remove-explicit-C-17-requirement.patch
@@ -1,0 +1,26 @@
+From 691202d1ac48f0ec98c17459e03ac954b8a7fad1 Mon Sep 17 00:00:00 2001
+From: Jacob Oursland <jacob.oursland@gmail.com>
+Date: Tue, 25 Feb 2025 08:54:08 -0800
+Subject: [PATCH] Revert "Mesh: Remove explicit C++17 requirement"
+
+This reverts commit 99b088e94e3a4116e88eb3e27c76c1c3b23c2169.
+---
+ src/Mod/Mesh/App/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/Mod/Mesh/App/CMakeLists.txt b/src/Mod/Mesh/App/CMakeLists.txt
+index e50866df11..59d1ee3a96 100644
+--- a/src/Mod/Mesh/App/CMakeLists.txt
++++ b/src/Mod/Mesh/App/CMakeLists.txt
+@@ -419,6 +419,8 @@ endif ()
+ 
+ add_library(Mesh SHARED ${Core_SRCS} ${WildMagic4_SRCS} ${Mesh_SRCS})
+ target_link_libraries(Mesh ${Mesh_LIBS})
++set_target_properties(Mesh PROPERTIES CXX_STANDARD_REQUIRED ON)
++set_target_properties(Mesh PROPERTIES CXX_STANDARD 17)
+ if (FREECAD_WARN_ERROR)
+     target_compile_warn_error(Mesh)
+ endif()
+-- 
+2.48.1
+


### PR DESCRIPTION
While CI is on Qt6, the weeklies are still on Qt5 until the development team agrees to move to Qt6.  As a consequence, the C++17 standard is still mandatory to build against Qt5.